### PR TITLE
Fixed compatibility for vpype 1.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # base
 click
-vpype
+vpype>=1.9,<2.0
 opencv-python-headless  # headless not to conflict with QT versions
 opensimplex==0.4
 tqdm

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     packages=["vpype_flow_imager"],
     install_requires=[
         'click',
-        'vpype',
+        'vpype>=1.9,<2.0',
         'opencv-python-headless',  # headless not to conflict with QT versions in vpype show
         'opensimplex==0.4',
         'tqdm',

--- a/vpype_flow_imager/vpype_flow_imager.py
+++ b/vpype_flow_imager/vpype_flow_imager.py
@@ -25,6 +25,7 @@ from PIL import Image
 
 import click
 import vpype as vp
+import vpype_cli
 
 import logging
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ eps = 1e-10
 
 
 @click.command("flow_img", context_settings={'show_default': True})
-@click.argument("filename", type=click.Path(exists=True))
+@click.argument("filename", type=vpype_cli.PathType(exists=True))
 @click.option(
     "-nc",
     "--noise_coeff",
@@ -129,11 +130,11 @@ eps = 1e-10
 @click.option(
         "-l",
         "--layer",
-        type=vp.LayerType(accept_new=True),
+        type=vpype_cli.LayerType(accept_new=True),
         default=None,
         help="Target layer or 'new'.  When CMYK enabled, this indicates the first (cyan) layer.",
     )
-@vp.global_processor
+@vpype_cli.global_processor
 def vpype_flow_imager(document, layer, filename, noise_coeff, n_fields,
                       min_sep, max_sep,
                       min_length, max_length, max_size,
@@ -153,7 +154,7 @@ def vpype_flow_imager(document, layer, filename, noise_coeff, n_fields,
         searcher_class = KDTSearcher
     else:
         searcher_class = HNSWSearcher
-    target_layer = vp.single_to_layer_id(layer, document)
+    target_layer = vpype_cli.single_to_layer_id(layer, document)
     img = cv2.imread(filename, cv2.IMREAD_UNCHANGED)
     logger.debug(f"original img.shape: {img.shape}")
     with tmp_np_seed(seed):


### PR DESCRIPTION
- Pinned vpype to 1.9 in setup.py and requirements.txt
- Fixed vpype-related imports
- Changed type of `filename` arg to make it compatible with expressions

Note: Ideally, all of the option types should be changed to support expressions. Unfortunately, vpype lacks a pure "float" type (could be emulated by vpype_cli.LengthType), as well as a "IntRange" type. I will add them in the next release.