### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For an existing *vpype* installation using pip in a virtual environment, activat
 $ pip install git+https://github.com/serycjon/vpype-flow-imager.git#egg=vpype-flow-imager
 ```
 
-Fopr a new installation of `vpype flow imager`, use the following commands:
+For a new installation of `vpype flow imager`, use the following commands:
 ```bash
 $ python3.8 -m venv my_virtual_env
 $ source my_virtual_env/bin/activate

--- a/README.md
+++ b/README.md
@@ -8,7 +8,19 @@
 
 You will need a C++ compiler before running the flow imager installation. One way of getting the compiler on Windows is installing Visual Studio with C++ package ([tutorial](https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-160)).
 
-Install `vpype flow imager` using the following commands:
+For an existing *vpype* installation using pipx, use the following command:
+
+```bash
+$ pipx inject vpype git+https://github.com/serycjon/vpype-flow-imager
+```
+
+For an existing *vpype* installation using pip in a virtual environment, activate the virtual environment and using the following command:
+
+```bash
+$ pip install git+https://github.com/serycjon/vpype-flow-imager.git#egg=vpype-flow-imager
+```
+
+Fopr a new installation of `vpype flow imager`, use the following commands:
 ```bash
 $ python3.8 -m venv my_virtual_env
 $ source my_virtual_env/bin/activate


### PR DESCRIPTION
pipx is now the [recommended way](https://vpype.readthedocs.io/en/latest/install.html) to install vpype. This has implications on how plug-ins are installed. I suggest the following addition to the installation instructions to cover this.

Further, I would also suggest suppressing the bit about creating a venv manually, as the pipx method is simpler and has many advantaged for inexperienced users.